### PR TITLE
Add option to disable check of blk group dsc size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 name = "ext4"
 readme = "README.md"
 repository = "https://github.com/FauxFaux/ext4-rs"
-version = "0.9.0"
+version = "0.9.1"
 
 edition = "2018"
 
@@ -22,7 +22,7 @@ anyhow = "1"
 bitflags = "1"
 byteorder = "1"
 crc = "1"
-positioned-io = "0.2"
+positioned-io2 = "0.3"
 thiserror = "1"
 
 [dev-dependencies]

--- a/src/extents.rs
+++ b/src/extents.rs
@@ -3,7 +3,7 @@ use std::io;
 
 use anyhow::ensure;
 use anyhow::Error;
-use positioned_io::ReadAt;
+use positioned_io2::ReadAt;
 
 use crate::assumption_failed;
 use crate::read_le16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,10 @@ impl Default for Checksums {
 #[derive(Debug, Default)]
 pub struct Options {
     pub checksums: Checksums,
+    /// If set to `true`, the check that the block group descriptor size is zero outside
+    /// long mode is skipped. This might be necessary to read some ext4 filesystems
+    /// created by possibly buggy tools or kernels.
+    pub ignore_nonzero_block_group_desc_size_outside_long_mode: bool,
 }
 
 impl<R> SuperBlock<R>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use anyhow::Context;
 use anyhow::Error;
 use bitflags::bitflags;
 use byteorder::{LittleEndian, ReadBytesExt};
-use positioned_io::ReadAt;
+use positioned_io2::ReadAt;
 
 mod block_groups;
 mod extents;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -305,7 +305,7 @@ where
         }
     };
 
-    if !long_structs {
+    if !long_structs && !options.ignore_nonzero_block_group_desc_size_outside_long_mode {
         ensure!(
             0 == s_desc_size,
             assumption_failed(format!(

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -11,8 +11,8 @@ use anyhow::Context;
 use anyhow::Error;
 use bitflags::bitflags;
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt};
-use positioned_io::Cursor;
-use positioned_io::ReadAt;
+use positioned_io2::Cursor;
+use positioned_io2::ReadAt;
 
 use crate::not_found;
 use crate::parse_error;

--- a/tests/generated-images.rs
+++ b/tests/generated-images.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::process::Stdio;
 
 use anyhow::Result;
-use positioned_io::ReadAt;
+use positioned_io2::ReadAt;
 use tempfile::NamedTempFile;
 use tempfile::TempDir;
 
@@ -34,7 +34,7 @@ fn all_types() -> Result<()> {
                 _ => panic!("unexpected partition table"),
             }
 
-            let part_reader = positioned_io::Slice::new(&mut img, part.first_byte, Some(part.len));
+            let part_reader = positioned_io2::Slice::new(&mut img, part.first_byte, Some(part.len));
             let superblock = ext4::SuperBlock::new(part_reader).unwrap();
             let root = superblock.root().unwrap();
             superblock


### PR DESCRIPTION
If set to true, the check that the block group descriptor size is zero
outside long mode is skipped. This is necessary to read some ext4
filesystems created by possibly buggy tools or kernels.

Fixes #4.