### PR TITLE
Block Group Descriptors: parsing 64bit images with s_desc_size <= 32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,6 @@ bootsector = "0.1"
 tempfile = "3"
 
 [features]
-default = ["verify-clean-state"]
+default = ["verify-clean-state", "verify-checksums"]
 verify-clean-state = []
+verify-checksums = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2018"
 repository = "FauxFaux/ext4-rs"
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1.0.58", features = ["backtrace"] }
 bitflags = "1"
 byteorder = "1"
 crc = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ thiserror = "1"
 [dev-dependencies]
 bootsector = "0.1"
 tempfile = "3"
+
+[features]
+default = ["verify-clean-state"]
+verify-clean-state = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ anyhow = { version = "1.0.58", features = ["backtrace"] }
 bitflags = "1"
 byteorder = "1"
 crc = "1"
-positioned-io = "0.2"
 thiserror = "1"
 
 [dev-dependencies]

--- a/examples/walk.rs
+++ b/examples/walk.rs
@@ -7,7 +7,7 @@ fn main() {
     let r = fs::File::open(env::args().nth(1).expect("one argument")).expect("openable file");
     let mut options = ext4::Options::default();
     options.checksums = ext4::Checksums::Enabled;
-    let vol = ext4::SuperBlock::new_with_options(r, &options).expect("ext4 volume");
+    let mut vol = ext4::SuperBlock::new_with_options(r, &options).expect("ext4 volume");
     let root = vol.root().expect("root");
     vol.walk(&root, "/", &mut |_, path, _, _| {
         println!("{}", path);

--- a/src/extents.rs
+++ b/src/extents.rs
@@ -127,10 +127,10 @@ impl<'a, R: ReadAt, C: Crypto, M: MetadataCrypto> io::Read for TreeReader<'a, R,
                     let page_addr =
                         (extent.start + (block_index - extent.part) as u64) * block_size;
 
-                    self.inner
-                        .read_at_without_decrypt(page_addr, page.as_mut_slice())?;
-
                     if let Some(context) = self.encryption_context {
+                        self.inner
+                            .read_at_without_decrypt(page_addr, page.as_mut_slice())?;
+
                         let page_offset = (block_index as u64) * block_size;
 
                         self.crypto
@@ -142,6 +142,8 @@ impl<'a, R: ReadAt, C: Crypto, M: MetadataCrypto> io::Read for TreeReader<'a, R,
                                 self.ino,
                             )
                             .map_err(map_lib_error_to_io)?;
+                    } else {
+                        self.inner.read_at(page_addr, page.as_mut_slice())?;
                     }
 
                     output.write(&page[offset_in_page..])?;

--- a/src/extents.rs
+++ b/src/extents.rs
@@ -7,7 +7,7 @@ use anyhow::Error;
 
 use crate::{
     assumption_failed, map_lib_error_to_io, read_le16, read_le32, Crypto, InnerReader,
-    MetadataCrypto, ReadAt
+    MetadataCrypto, ReadAt,
 };
 
 #[derive(Debug)]
@@ -319,9 +319,11 @@ mod tests {
         let size = 4 + 4 * 2;
         let crypto = NoneCrypto {};
         let metadata_crypto = NoneCrypto {};
-        let data = InnerReader::new((0..255u8).collect::<Vec<u8>>(), metadata_crypto);
+
+        let cursor = std::io::Cursor::new((0..255u8).collect::<Vec<u8>>());
+        let mut data = InnerReader::new(cursor, metadata_crypto);
         let mut reader = TreeReader::create(
-            &data,
+            &mut data,
             4,
             u64::try_from(size).expect("infallible u64 conversion"),
             vec![

--- a/src/extents.rs
+++ b/src/extents.rs
@@ -98,10 +98,6 @@ fn find_part(part: u32, extents: &[Extent]) -> FoundPart {
     FoundPart::Sparse(std::u32::MAX)
 }
 
-impl<'a, R: ReadAt, C: Crypto, M: MetadataCrypto> TreeReader<'a, R, C, M> {
-    // fn decrypt_page(&mut self)
-}
-
 impl<'a, R: ReadAt, C: Crypto, M: MetadataCrypto> io::Read for TreeReader<'a, R, C, M> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if buf.is_empty() {

--- a/src/extents.rs
+++ b/src/extents.rs
@@ -130,24 +130,25 @@ where
                     let mut read_offset = 0;
                     while read_offset < to_read {
                         let mut new_buf = vec![0u8; block_size as usize];
-                        let read = self
-                            .inner
-                            .read_at(offset + read_offset, &mut new_buf[0..block_size as usize])?;
+                        let read = self.inner.read_at(
+                            offset + read_offset as u64,
+                            &mut new_buf[0..block_size as usize],
+                        )?;
 
                         self.crypto
                             .decrypt_page(
                                 context,
                                 &mut new_buf[0..block_size as usize],
-                                offset + read_offset,
+                                offset + read_offset as u64,
                             )
                             .unwrap();
 
-                        let counter = min(to_read, read_offset + block_size);
+                        let counter = min(to_read, read_offset + block_size as usize);
                         for i in read_offset..counter {
                             buf[i] = new_buf[i - read_offset];
                         }
 
-                        read_offset += block_size;
+                        read_offset += block_size as usize;
                     }
 
                     to_read

--- a/src/extents.rs
+++ b/src/extents.rs
@@ -147,7 +147,7 @@ where
 
                         let expected_size = min(to_read - read_offset, chunk_size);
                         buf[read_offset..read_offset + expected_size]
-                            .copy_from_slice(&block_buffer);
+                            .copy_from_slice(block_buffer[..expected_size]);
 
                         read_offset += chunk_size;
                     }

--- a/src/extents.rs
+++ b/src/extents.rs
@@ -323,10 +323,7 @@ mod tests {
         let size = 4 + 4 * 2;
         let crypto = NoneCrypto {};
         let metadata_crypto = NoneCrypto {};
-        let data = InnerReader {
-            inner: (0..255u8).collect::<Vec<u8>>(),
-            metadata_crypto,
-        };
+        let data = InnerReader::new((0..255u8).collect::<Vec<u8>>(), metadata_crypto);
         let mut reader = TreeReader::create(
             &data,
             4,

--- a/src/extents.rs
+++ b/src/extents.rs
@@ -39,7 +39,7 @@ where
         checksum_prefix: Option<u32>,
         encryption_context: Option<&'a Vec<u8>>,
         crypto: &'a C,
-    ) -> Result<TreeReader<R, C>, Error> {
+    ) -> Result<TreeReader<'a, R, C>, Error> {
         let extents = load_extent_tree(
             &mut |block| crate::load_disc_bytes(&inner, block_size, block),
             core,
@@ -62,7 +62,7 @@ where
         extents: Vec<Extent>,
         encryption_context: Option<&'a Vec<u8>>,
         crypto: &'a C,
-    ) -> TreeReader<R, C> {
+    ) -> TreeReader<'a, R, C> {
         TreeReader {
             pos: 0,
             len: size,

--- a/src/extents.rs
+++ b/src/extents.rs
@@ -4,11 +4,10 @@ use std::io;
 
 use anyhow::ensure;
 use anyhow::Error;
-use positioned_io::ReadAt;
 
 use crate::{
     assumption_failed, map_lib_error_to_io, read_le16, read_le32, Crypto, InnerReader,
-    MetadataCrypto,
+    MetadataCrypto, ReadAt
 };
 
 #[derive(Debug)]
@@ -20,7 +19,7 @@ struct Extent {
 }
 
 pub struct TreeReader<'a, R: ReadAt, C: Crypto, M: MetadataCrypto> {
-    inner: &'a InnerReader<R, M>,
+    inner: &'a mut InnerReader<R, M>,
     pos: u64,
     len: u64,
     block_size: u32,
@@ -31,7 +30,7 @@ pub struct TreeReader<'a, R: ReadAt, C: Crypto, M: MetadataCrypto> {
 
 impl<'a, R: ReadAt, C: Crypto, M: MetadataCrypto> TreeReader<'a, R, C, M> {
     pub fn new(
-        inner: &'a InnerReader<R, M>,
+        inner: &'a mut InnerReader<R, M>,
         block_size: u32,
         size: u64,
         core: [u8; crate::INODE_CORE_SIZE],
@@ -55,7 +54,7 @@ impl<'a, R: ReadAt, C: Crypto, M: MetadataCrypto> TreeReader<'a, R, C, M> {
     }
 
     fn create(
-        inner: &'a InnerReader<R, M>,
+        inner: &'a mut InnerReader<R, M>,
         block_size: u32,
         size: u64,
         extents: Vec<Extent>,

--- a/src/extents.rs
+++ b/src/extents.rs
@@ -6,9 +6,10 @@ use anyhow::ensure;
 use anyhow::Error;
 use positioned_io::ReadAt;
 
-use crate::{assumption_failed, Crypto, InnerReader};
-use crate::{map_lib_error_to_io, read_le16};
-use crate::{read_le32, MetadataCrypto};
+use crate::{
+    assumption_failed, map_lib_error_to_io, read_le16, read_le32, Crypto, InnerReader,
+    MetadataCrypto,
+};
 
 #[derive(Debug)]
 struct Extent {

--- a/src/extents.rs
+++ b/src/extents.rs
@@ -147,7 +147,7 @@ where
 
                         let expected_size = min(to_read - read_offset, chunk_size);
                         buf[read_offset..read_offset + expected_size]
-                            .copy_from_slice(block_buffer[..expected_size]);
+                            .copy_from_slice(&block_buffer[..expected_size]);
 
                         read_offset += chunk_size;
                     }

--- a/src/extents.rs
+++ b/src/extents.rs
@@ -152,7 +152,7 @@ where
                         read_offset += chunk_size;
                     }
 
-                    read
+                    to_read
                 } else {
                     self.inner.read_at(offset, &mut buf[0..to_read])?
                 };

--- a/src/inner_reader.rs
+++ b/src/inner_reader.rs
@@ -1,6 +1,6 @@
 use std::cmp::min;
 use std::io;
-use std::io::ErrorKind;
+use std::io::{ErrorKind, SeekFrom};
 
 use anyhow::Error;
 use positioned_io::ReadAt;
@@ -35,24 +35,35 @@ impl<R: ReadAt, M: MetadataCrypto> InnerReader<R, M> {
     ) -> io::Result<usize> {
         let mut read_offset = 0;
         const CHUNK_SIZE: usize = 0x1000;
-        let to_read = buf.len();
 
-        while read_offset < to_read {
-            let mut block_buffer = vec![0u8; CHUNK_SIZE];
-            let address = pos + read_offset as u64;
-            read_fn(address, &mut block_buffer)?;
+        let aligned_address = (pos / CHUNK_SIZE as u64) * CHUNK_SIZE as u64;
+        let aligned_delta = (pos - aligned_address) as usize;
+
+        let data_size = buf.len();
+        let to_read = data_size + aligned_delta;
+
+        let to_read = if to_read - ((to_read / CHUNK_SIZE) * CHUNK_SIZE) == 0 {
+            to_read
+        } else {
+            ((to_read / CHUNK_SIZE) * CHUNK_SIZE) + CHUNK_SIZE
+        };
+
+        let mut buffer = vec![0u8; to_read];
+
+        for block_buffer in buffer.chunks_mut(CHUNK_SIZE) {
+            let address = aligned_address + read_offset as u64;
+            read_fn(address, block_buffer)?;
+
             self.metadata_crypto
-                .decrypt(&mut block_buffer, address)
+                .decrypt(block_buffer, address)
                 .map_err(|error| io::Error::new(ErrorKind::Other, error.to_string()))?;
-
-            let expected_size = min(to_read - read_offset, CHUNK_SIZE);
-            buf[read_offset..read_offset + expected_size]
-                .copy_from_slice(&block_buffer[..expected_size]);
 
             read_offset += CHUNK_SIZE;
         }
 
-        Ok(to_read)
+        buf.copy_from_slice(&buffer[aligned_delta..buf.len() + aligned_delta]);
+
+        Ok(data_size)
     }
 }
 

--- a/src/inner_reader.rs
+++ b/src/inner_reader.rs
@@ -52,7 +52,7 @@ impl<R: ReadAt, M: MetadataCrypto> InnerReader<R, M> {
             read_offset += CHUNK_SIZE;
         }
 
-        Ok(read_offset)
+        Ok(to_read)
     }
 }
 

--- a/src/inner_reader.rs
+++ b/src/inner_reader.rs
@@ -1,6 +1,5 @@
-use std::cmp::min;
 use std::io;
-use std::io::{ErrorKind, SeekFrom};
+use std::io::ErrorKind;
 
 use anyhow::Error;
 use positioned_io::ReadAt;
@@ -42,7 +41,7 @@ impl<R: ReadAt, M: MetadataCrypto> InnerReader<R, M> {
         let data_size = buf.len();
         let to_read = data_size + aligned_delta;
 
-        let to_read = if to_read - ((to_read / CHUNK_SIZE) * CHUNK_SIZE) == 0 {
+        let to_read = if to_read % CHUNK_SIZE == 0 {
             to_read
         } else {
             ((to_read / CHUNK_SIZE) * CHUNK_SIZE) + CHUNK_SIZE

--- a/src/inner_reader.rs
+++ b/src/inner_reader.rs
@@ -12,7 +12,7 @@ pub trait MetadataCrypto {
 #[derive(Debug)]
 pub struct InnerReader<R: ReadAt, M: MetadataCrypto> {
     pub inner: R,
-    metadata_crypto: M,
+    pub metadata_crypto: M,
 }
 
 impl<R: ReadAt, M: MetadataCrypto> InnerReader<R, M> {

--- a/src/inner_reader.rs
+++ b/src/inner_reader.rs
@@ -1,0 +1,74 @@
+use std::cmp::min;
+use std::io;
+use std::io::ErrorKind;
+
+use anyhow::Error;
+use positioned_io::ReadAt;
+
+pub trait MetadataCrypto {
+    fn decrypt(&self, page: &mut [u8], page_addr: u64) -> Result<(), Error>;
+}
+
+#[derive(Debug)]
+pub struct InnerReader<R: ReadAt, M: MetadataCrypto> {
+    pub inner: R,
+    metadata_crypto: M,
+}
+
+impl<R: ReadAt, M: MetadataCrypto> InnerReader<R, M> {
+    pub fn new(inner: R, metadata_crypto: M) -> InnerReader<R, M> {
+        Self {
+            inner,
+            metadata_crypto,
+        }
+    }
+
+    pub fn read_at_without_decrypt(&self, pos: u64, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read_at(pos, buf)
+    }
+
+    fn decrypt<F: Fn(u64, &mut [u8]) -> io::Result<usize>>(
+        &self,
+        pos: u64,
+        buf: &mut [u8],
+        read_fn: F,
+    ) -> io::Result<usize> {
+        let mut read_offset = 0;
+        const CHUNK_SIZE: usize = 0x1000;
+        let to_read = buf.len();
+
+        while read_offset < to_read {
+            let mut block_buffer = vec![0u8; CHUNK_SIZE];
+            let address = pos + read_offset as u64;
+            read_fn(address, &mut block_buffer)?;
+            self.metadata_crypto
+                .decrypt(&mut block_buffer, address)
+                .map_err(|error| io::Error::new(ErrorKind::Other, error.to_string()))?;
+
+            let expected_size = min(to_read - read_offset, CHUNK_SIZE);
+            buf[read_offset..read_offset + expected_size]
+                .copy_from_slice(&block_buffer[..expected_size]);
+
+            read_offset += CHUNK_SIZE;
+        }
+
+        Ok(read_offset)
+    }
+}
+
+impl<R: ReadAt, M: MetadataCrypto> ReadAt for InnerReader<R, M> {
+    fn read_at(&self, pos: u64, buf: &mut [u8]) -> io::Result<usize> {
+        self.decrypt(pos, buf, |offset, buffer| {
+            self.read_at_without_decrypt(offset, buffer)
+        })
+    }
+
+    fn read_exact_at(&self, pos: u64, buf: &mut [u8]) -> io::Result<()> {
+        self.decrypt(pos, buf, |offset, buffer| {
+            self.inner.read_exact_at(offset, buffer)?;
+            Ok(0)
+        })?;
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,12 +609,10 @@ impl<'a, C: Crypto> Inode<'a, C> {
                     name
                 };
 
-                if let Some(new_size) = name.iter().rev().position(|current| *current != 0) {
-                    name.resize(new_size + 1, 0);
-                }
-
+                let forbidden_chars: &[_] = &['\0'];
                 let name = std::str::from_utf8(&name)
-                    .map_err(|e| parse_error(format!("invalid utf-8 in file name: {}", e)))?;
+                    .map_err(|e| parse_error(format!("invalid utf-8 in file name: {}", e)))?
+                    .trim_end_matches(forbidden_chars);
 
                 dirs.push(DirEntry {
                     inode: child_inode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,7 +438,7 @@ impl<R: ReadAt, C: Crypto, M: MetadataCrypto> SuperBlock<R, C, M> {
     /// The method returns `true` if the closure always returned true.
     pub fn walk<F>(&mut self, inode: &Inode, path: &str, visit: &mut F) -> Result<bool, Error>
     where
-        F: FnMut(&Self, &str, &Inode, &Enhanced) -> Result<bool, Error>,
+        F: FnMut(&mut Self, &str, &Inode, &Enhanced) -> Result<bool, Error>,
     {
         let enhanced = inode.enhance(&mut self.inner, &self.crypto)?;
 
@@ -519,8 +519,8 @@ impl<R: ReadAt, C: Crypto, M: MetadataCrypto> SuperBlock<R, C, M> {
     }
 
     /// Read the data from an inode. You might not want to call this on thigns that aren't regular files.
-    pub fn open<'a>(&'a mut self, inode: &'a Inode, crypto: &'a C) -> Result<TreeReader<'a, R, C, M>, Error> {
-        inode.reader(&mut self.inner, crypto)
+    pub fn open<'a>(&'a mut self, inode: &'a Inode) -> Result<TreeReader<'a, R, C, M>, Error> {
+        inode.reader(&mut self.inner, &self.crypto)
     }
 
     /// Load extra metadata about some types of entries.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,6 +301,10 @@ where
         &mut self.crypto
     }
 
+    pub fn get_crypto(&self) -> &C {
+        &self.crypto
+    }
+
     pub fn set_crypto(&mut self, crypto: C) {
         self.crypto = crypto;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -594,9 +594,7 @@ impl Inode {
                     self.core[0..usize::try_from(self.stat.size)?].to_vec()
                 } else {
                     ensure!(
-                        Self::only_relevant_flag_is_extents_static(
-                            self.flags & !InodeFlags::ENCRYPT
-                        ),
+                        Self::only_relevant_flag_is_extents(self.flags & !InodeFlags::ENCRYPT),
                         unsupported_feature(format!(
                             "symbolic links may not have non-extent flags: {:?}",
                             self.flags
@@ -664,7 +662,8 @@ impl Inode {
         let data = {
             // if the flags, minus irrelevant flags, isn't just EXTENTS...
             ensure!(
-                self.get_encryption_context().is_some() || self.only_relevant_flag_is_extents(),
+                self.get_encryption_context().is_some()
+                    || Self::only_relevant_flag_is_extents(self.flags),
                 unsupported_feature(format!(
                     "inode with unsupported flags: {0:x} {0:b}",
                     self.flags
@@ -764,11 +763,7 @@ impl Inode {
         Ok(dirs)
     }
 
-    fn only_relevant_flag_is_extents(&self) -> bool {
-        Self::only_relevant_flag_is_extents_static(self.flags)
-    }
-
-    fn only_relevant_flag_is_extents_static(flags: InodeFlags) -> bool {
+    fn only_relevant_flag_is_extents(flags: InodeFlags) -> bool {
         flags
             & (InodeFlags::COMPR
                 | InodeFlags::DIRTY

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,7 +601,7 @@ impl<'a, C: Crypto> Inode<'a, C> {
 
             if 0 != child_inode {
                 let mut name = if self.get_encryption_context().is_some()
-                    && [b".".as_slice(), b"..".as_slice()].contains(&name.as_slice())
+                    && ![b".".as_slice(), b"..".as_slice()].contains(&name.as_slice())
                 {
                     self.crypto
                         .decrypt_filename(self.get_encryption_context().unwrap(), &name)?
@@ -610,7 +610,7 @@ impl<'a, C: Crypto> Inode<'a, C> {
                 };
 
                 if let Some(new_size) = name.iter().rev().position(|current| *current != 0) {
-                    name.resize(new_size, 0);
+                    name.resize(new_size + 1, 0);
                 }
 
                 let name = std::str::from_utf8(&name)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,10 +151,13 @@ bitflags! {
         const TOPDIR       = 0x0002_0000; /* Top of directory hierarchies*/
         const HUGE_FILE    = 0x0004_0000; /* Set to each huge file */
         const EXTENTS      = 0x0008_0000; /* Inode uses extents */
+        const VERITY       = 0x0010_0000; /* Verity protected inode */
         const EA_INODE     = 0x0020_0000; /* Inode used for large EA */
         const EOFBLOCKS    = 0x0040_0000; /* Blocks allocated beyond EOF */
+        const DAX          = 0x0200_0000; /* Inode is DAX */
         const INLINE_DATA  = 0x1000_0000; /* Inode has inline data. */
         const PROJINHERIT  = 0x2000_0000; /* Create with parents projid */
+        const CASEFOLD     = 0x4000_0000; /* Casefolded directory */
         const RESERVED     = 0x8000_0000; /* reserved for ext4 lib */
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,9 +480,10 @@ impl<'a, C: Crypto> Inode<'a, C> {
     where
         R: ReadAt,
     {
-        let context = match self.stat.extracted_type {
-            FileType::RegularFile => self.get_encryption_context(),
-            _ => None,
+        let context = if matches!(self.stat.extracted_type, FileType::RegularFile) {
+            self.get_encryption_context()
+        } else {
+            None
         };
 
         Ok(TreeReader::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ mod none_crypto;
 pub mod parse;
 
 use crate::extents::TreeReader;
-use crate::none_crypto::NoneCrypto;
+pub use crate::none_crypto::NoneCrypto;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,7 @@ pub struct SuperBlock<R: ReadAt, C: Crypto, M: MetadataCrypto> {
     load_xattrs: bool,
     /// All* checksums are computed after concatenation with the UUID, so we keep that.
     uuid_checksum: Option<u32>,
+    uuid: [u8; 16],
     groups: block_groups::BlockGroups,
     crypto: C,
 }
@@ -302,6 +303,10 @@ impl<R: ReadAt, C: Crypto, M: MetadataCrypto> SuperBlock<R, C, M> {
         metadata_crypto: M,
     ) -> Result<SuperBlock<R, C, M>, Error> {
         Self::new_with_options_and_crypto(inner, &Options::default(), crypto, metadata_crypto)
+    }
+
+    pub fn get_uuid(&self) -> &[u8; 16] {
+        &self.uuid
     }
 
     pub fn get_crypto_mut(&mut self) -> &mut C {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,6 +314,10 @@ where
         self.inner
     }
 
+    pub fn ref_inner(&self) -> &R {
+        &self.inner
+    }
+
     pub fn new_with_options_and_crypto(
         inner: R,
         options: &Options,
@@ -613,12 +617,11 @@ impl<'a, C: Crypto> Inode<'a, C> {
                     name
                 };
 
-                while name.iter().last().unwrap() == 0 {
+                while name.iter().last().unwrap() == &0 {
                     name.pop();
                 }
 
                 if let Ok(name) = std::str::from_utf8(&name) {
-
                     dirs.push(DirEntry {
                         inode: child_inode,
                         name: name.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,13 @@ pub struct Stat {
 const INODE_CORE_SIZE: usize = 4 * 15;
 
 pub trait Crypto {
-    fn decrypt_filename(&self, context: &[u8], encrypted_name: &[u8]) -> Result<Vec<u8>, Error>;
+    fn decrypt_filename(
+        &self,
+        context: &[u8],
+        encrypted_name: &[u8],
+        ino: u32,
+    ) -> Result<Vec<u8>, Error>;
+
     fn decrypt_page(
         &self,
         context: &[u8],
@@ -626,7 +632,8 @@ impl Inode {
                         anyhow!("encrypted short symlink has no encryption context")
                     })?;
 
-                    points_to = crypto.decrypt_filename(context, &encrypted_filename)?;
+                    points_to =
+                        crypto.decrypt_filename(context, &encrypted_filename, self.number)?;
                 }
 
                 let points_to = std::str::from_utf8(&points_to)
@@ -710,7 +717,7 @@ impl Inode {
                     self.get_encryption_context(),
                     [b".".as_slice(), b"..".as_slice()].contains(&name.as_slice()),
                 ) {
-                    crypto.decrypt_filename(context, &name)?
+                    crypto.decrypt_filename(context, &name, child_inode)?
                 } else {
                     name
                 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,6 +301,10 @@ where
         &mut self.crypto
     }
 
+    pub fn set_crypto(&mut self, crypto: C) {
+        self.crypto = crypto;
+    }
+
     /// Returns inner R, consuming self
     pub fn into_inner(self) -> R {
         self.inner

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,6 @@ where
         SuperBlock::new_with_options(inner, &Options::default())
     }
 
-
     /// Returns inner R, consuming self
     pub fn into_inner(self) -> R {
         self.inner
@@ -351,8 +350,11 @@ where
                 let child_node = self
                     .load_inode(entry.inode)
                     .with_context(|| anyhow!("loading {} ({:?})", entry.name, entry.file_type))?;
+
+                let path = std::path::Path::new(path).join(&entry.name);
+
                 if !self
-                    .walk(&child_node, &format!("{}/{}", path, entry.name), visit)
+                    .walk(&child_node, &path.to_string_lossy(), visit)
                     .with_context(|| anyhow!("processing '{}'", entry.name))?
                 {
                     return Ok(false);
@@ -369,7 +371,9 @@ where
     /// Parse a path, and find the directory entry it represents.
     /// Note that "/foo/../bar" will be treated literally, not resolved to "/bar" then looked up.
     pub fn resolve_path(&self, path: &str) -> Result<DirEntry, Error> {
+        let path = path.replace('\\', "/");
         let path = path.trim_end_matches('/');
+
         if path.is_empty() {
             // this is a bit of a lie, but it works..?
             return Ok(DirEntry {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ use std::convert::TryFrom;
 use std::io;
 use std::io::Read;
 use std::io::Seek;
-use std::rc::Rc;
 
 use anyhow::anyhow;
 use anyhow::ensure;
@@ -35,10 +34,12 @@ use positioned_io::ReadAt;
 mod block_groups;
 mod extents;
 
+mod none_crypto;
 /// Raw object parsing API. Not versioned / supported.
 pub mod parse;
 
 use crate::extents::TreeReader;
+use crate::none_crypto::NoneCrypto;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
@@ -192,7 +193,7 @@ pub trait Crypto {
 }
 
 /// An actual disc metadata entry.
-pub struct Inode {
+pub struct Inode<'a, C: Crypto> {
     pub stat: Stat,
     pub number: u32,
     flags: InodeFlags,
@@ -203,17 +204,18 @@ pub struct Inode {
     /// I made up a new name.
     core: [u8; INODE_CORE_SIZE],
     block_size: u32,
-    crypto: Option<Rc<dyn Crypto>>,
+    crypto: &'a C,
 }
 
 /// The critical core of the filesystem.
 #[derive(Debug)]
-pub struct SuperBlock<R> {
+pub struct SuperBlock<R, C: Crypto> {
     inner: R,
     load_xattrs: bool,
     /// All* checksums are computed after concatenation with the UUID, so we keep that.
     uuid_checksum: Option<u32>,
     groups: block_groups::BlockGroups,
+    crypto: C,
 }
 
 /// A raw filesystem time.
@@ -273,13 +275,17 @@ pub struct Options {
     pub checksums: Checksums,
 }
 
-impl<R> SuperBlock<R>
+impl<R, C: Crypto> SuperBlock<R, C>
 where
     R: ReadAt,
 {
     /// Open a filesystem, and load its superblock.
-    pub fn new(inner: R) -> Result<SuperBlock<R>, Error> {
-        SuperBlock::new_with_options(inner, &Options::default())
+    pub fn new(inner: R) -> Result<SuperBlock<R, NoneCrypto>, Error> {
+        SuperBlock::new_with_options(inner, &Options::default(), NoneCrypto {})
+    }
+
+    pub fn new_with_crypto(inner: R, crypto: C) -> Result<SuperBlock<R, C>, Error> {
+        SuperBlock::new_with_options(inner, &Options::default(), crypto)
     }
 
     /// Returns inner R, consuming self
@@ -287,13 +293,17 @@ where
         self.inner
     }
 
-    pub fn new_with_options(inner: R, options: &Options) -> Result<SuperBlock<R>, Error> {
-        Ok(parse::superblock(inner, options)
+    pub fn new_with_options(
+        inner: R,
+        options: &Options,
+        crypto: C,
+    ) -> Result<SuperBlock<R, C>, Error> {
+        Ok(parse::superblock(inner, options, crypto)
             .with_context(|| anyhow!("failed to parse superblock"))?)
     }
 
     /// Load a filesystem entry by inode number.
-    pub fn load_inode(&self, inode: u32) -> Result<Inode, Error> {
+    pub fn load_inode<'a>(&'a self, inode: u32) -> Result<Inode<'a, C>, Error> {
         let data = self
             .load_inode_bytes(inode)
             .with_context(|| anyhow!("failed to find inode <{}> on disc", inode))?;
@@ -314,16 +324,8 @@ where
             core: parsed.core,
             checksum_prefix: parsed.checksum_prefix,
             block_size: self.groups.block_size,
-            crypto: None,
+            crypto: &self.crypto,
         })
-    }
-
-    /// Load a filesystem entry by inode number.
-    pub fn load_crypted_inode(&self, inode: u32, crypto: Rc<dyn Crypto>) -> Result<Inode, Error> {
-        let mut inode = self.load_inode(inode)?;
-        inode.crypto = Some(crypto);
-
-        Ok(inode)
     }
 
     fn load_inode_bytes(&self, inode: u32) -> Result<Vec<u8>, Error> {
@@ -338,7 +340,7 @@ where
     }
 
     /// Load the root node of the filesystem (typically `/`).
-    pub fn root(&self) -> Result<Inode, Error> {
+    pub fn root(&self) -> Result<Inode<C>, Error> {
         Ok(self
             .load_inode(2)
             .with_context(|| anyhow!("failed to load root inode"))?)
@@ -347,9 +349,9 @@ where
     /// Visit every entry in the filesystem in an arbitrary order.
     /// The closure should return `true` if it wants walking to continue.
     /// The method returns `true` if the closure always returned true.
-    pub fn walk<F>(&self, inode: &Inode, path: &str, visit: &mut F) -> Result<bool, Error>
+    pub fn walk<F>(&self, inode: &Inode<C>, path: &str, visit: &mut F) -> Result<bool, Error>
     where
-        F: FnMut(&Self, &str, &Inode, &Enhanced) -> Result<bool, Error>,
+        F: FnMut(&Self, &str, &Inode<C>, &Enhanced) -> Result<bool, Error>,
     {
         let enhanced = inode.enhance(&self.inner)?;
 
@@ -415,7 +417,7 @@ where
         self.dir_entry_named(&curr, last)
     }
 
-    fn dir_entry_named(&self, inode: &Inode, name: &str) -> Result<DirEntry, Error> {
+    fn dir_entry_named(&self, inode: &Inode<C>, name: &str) -> Result<DirEntry, Error> {
         if let Enhanced::Directory(entries) = self.enhance(inode)? {
             if let Some(en) = entries.into_iter().find(|entry| entry.name == name) {
                 Ok(en)
@@ -428,12 +430,12 @@ where
     }
 
     /// Read the data from an inode. You might not want to call this on thigns that aren't regular files.
-    pub fn open<'a>(&'a self, inode: &'a Inode) -> Result<TreeReader<'a, &R>, Error> {
+    pub fn open<'a>(&'a self, inode: &'a Inode<C>) -> Result<TreeReader<'a, &R, C>, Error> {
         inode.reader(&self.inner)
     }
 
     /// Load extra metadata about some types of entries.
-    pub fn enhance(&self, inode: &Inode) -> Result<Enhanced, Error> {
+    pub fn enhance(&self, inode: &Inode<C>) -> Result<Enhanced, Error> {
         inode.enhance(&self.inner)
     }
 }
@@ -448,8 +450,8 @@ where
     Ok(data)
 }
 
-impl Inode {
-    fn reader<R>(&self, inner: R) -> Result<TreeReader<R>, Error>
+impl<'a, C: Crypto> Inode<'a, C> {
+    fn reader<R>(&self, inner: R) -> Result<TreeReader<R, C>, Error>
     where
         R: ReadAt,
     {
@@ -460,7 +462,7 @@ impl Inode {
             self.core,
             self.checksum_prefix,
             self.get_encryption_context(),
-            self.crypto.clone(),
+            self.crypto,
         )
         .with_context(|| anyhow!("opening inode <{}>", self.number))?)
     }
@@ -568,11 +570,7 @@ impl Inode {
             cursor.read_exact(&mut name)?;
             if 0 != child_inode {
                 let name = if let Some(context) = self.get_encryption_context() {
-                    let crypto = self
-                        .crypto
-                        .as_ref()
-                        .with_context(|| anyhow!("directory is encrypted"))?;
-                    crypto.decrypt_filename(context, &name)?
+                    self.crypto.decrypt_filename(context, &name)?
                 } else {
                     name
                 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -591,7 +591,10 @@ impl Inode {
                         ))
                     );
 
-                    self.core[0..usize::try_from(self.stat.size)?].to_vec()
+                    let mut points_to = vec![0u8; usize::try_from(self.stat.size)?];
+                    io::Cursor::new(&self.core).read_exact(&mut points_to)?;
+
+                    points_to
                 } else {
                     ensure!(
                         Self::only_relevant_flag_is_extents(self.flags & !InodeFlags::ENCRYPT),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,14 @@ const INODE_CORE_SIZE: usize = 4 * 15;
 
 pub trait Crypto {
     fn decrypt_filename(&self, context: &[u8], encrypted_name: &[u8]) -> Result<Vec<u8>, Error>;
-    fn decrypt_page(&self, context: &[u8], page: &mut [u8], page_addr: u64) -> Result<(), Error>;
+    fn decrypt_page(
+        &self,
+        context: &[u8],
+        page: &mut [u8],
+        page_offset: u64,
+        page_addr: u64,
+        ino: u32,
+    ) -> Result<(), Error>;
 }
 
 /// An actual disc metadata entry.
@@ -566,6 +573,7 @@ impl Inode {
             self.checksum_prefix,
             context,
             crypto,
+            self.number,
         )
         .with_context(|| anyhow!("opening inode <{}>", self.number))?)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,6 +297,10 @@ where
         Self::new_with_options_and_crypto(inner, &Options::default(), crypto)
     }
 
+    pub fn get_crypto_mut(&mut self) -> &mut C {
+        &mut self.crypto
+    }
+
     /// Returns inner R, consuming self
     pub fn into_inner(self) -> R {
         self.inner

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ file on the filesystem. You can grant yourself temporary access with
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::io;
-use std::io::Seek;
+use std::io::{Seek, SeekFrom};
 use std::io::{ErrorKind, Read};
 
 use anyhow::anyhow;
@@ -29,7 +29,6 @@ use anyhow::Context;
 use anyhow::Error;
 use bitflags::bitflags;
 use byteorder::{LittleEndian, ReadBytesExt};
-use positioned_io::ReadAt;
 
 mod block_groups;
 mod extents;
@@ -42,6 +41,46 @@ pub mod parse;
 use crate::extents::TreeReader;
 pub use crate::none_crypto::NoneCrypto;
 pub use inner_reader::{InnerReader, MetadataCrypto};
+
+pub trait ReadAt {
+    /// Read bytes from an offset in this source into a buffer, returning how many bytes were read.
+    ///
+    /// This function may yield fewer bytes than the size of `buf`, if it was interrupted or hit
+    /// end-of-file.
+    ///
+    /// See [`Read::read()`](https://doc.rust-lang.org/std/io/trait.Read.html#tymethod.read).
+    fn read_at(&mut self, pos: u64, buf: &mut [u8]) -> io::Result<usize>;
+
+    /// Read the exact number of bytes required to fill `buf`, from an offset.
+    ///
+    /// If only a lesser number of bytes can be read, will yield an error.
+    fn read_exact_at(&mut self, mut pos: u64, mut buf: &mut [u8]) -> io::Result<()> {
+        while !buf.is_empty() {
+            match self.read_at(pos, buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let tmp = buf;
+                    buf = &mut tmp[n..];
+                    pos += n as u64;
+                }
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        if !buf.is_empty() {
+            Err(io::Error::new(ErrorKind::UnexpectedEof, "failed to fill whole buffer"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<T> ReadAt for T where T: Read + Seek {
+    fn read_at(&mut self, pos: u64, buf: &mut [u8]) -> io::Result<usize> {
+        self.seek(SeekFrom::Start(pos))?;
+        self.read(buf)
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
@@ -202,7 +241,7 @@ pub trait Crypto {
 }
 
 /// An actual disc metadata entry.
-pub struct Inode<'a, C: Crypto> {
+pub struct Inode {
     pub stat: Stat,
     pub number: u32,
     flags: InodeFlags,
@@ -213,7 +252,6 @@ pub struct Inode<'a, C: Crypto> {
     /// I made up a new name.
     core: [u8; INODE_CORE_SIZE],
     block_size: u32,
-    crypto: &'a C,
 }
 
 /// The critical core of the filesystem.
@@ -353,7 +391,7 @@ impl<R: ReadAt, C: Crypto, M: MetadataCrypto> SuperBlock<R, C, M> {
     }
 
     /// Load a filesystem entry by inode number.
-    pub fn load_inode(&self, inode: u32) -> Result<Inode<C>, Error> {
+    pub fn load_inode(&mut self, inode: u32) -> Result<Inode, Error> {
         let data = self
             .load_inode_bytes(inode)
             .with_context(|| anyhow!("failed to find inode <{}> on disc", inode))?;
@@ -374,23 +412,22 @@ impl<R: ReadAt, C: Crypto, M: MetadataCrypto> SuperBlock<R, C, M> {
             core: parsed.core,
             checksum_prefix: parsed.checksum_prefix,
             block_size: self.groups.block_size,
-            crypto: &self.crypto,
         })
     }
 
-    fn load_inode_bytes(&self, inode: u32) -> Result<Vec<u8>, Error> {
+    fn load_inode_bytes(&mut self, inode: u32) -> Result<Vec<u8>, Error> {
         let offset = self.groups.index_of(inode)?;
         let mut data = vec![0u8; usize::try_from(self.groups.inode_size)?];
         self.inner.read_exact_at(offset, &mut data)?;
         Ok(data)
     }
 
-    fn load_disc_bytes(&self, block: u64) -> Result<Vec<u8>, Error> {
-        load_disc_bytes(&self.inner, self.groups.block_size, block)
+    fn load_disc_bytes(&mut self, block: u64) -> Result<Vec<u8>, Error> {
+        load_disc_bytes(&mut self.inner, self.groups.block_size, block)
     }
 
     /// Load the root node of the filesystem (typically `/`).
-    pub fn root(&self) -> Result<Inode<C>, Error> {
+    pub fn root(&mut self) -> Result<Inode, Error> {
         Ok(self
             .load_inode(2)
             .with_context(|| anyhow!("failed to load root inode"))?)
@@ -399,11 +436,11 @@ impl<R: ReadAt, C: Crypto, M: MetadataCrypto> SuperBlock<R, C, M> {
     /// Visit every entry in the filesystem in an arbitrary order.
     /// The closure should return `true` if it wants walking to continue.
     /// The method returns `true` if the closure always returned true.
-    pub fn walk<F>(&self, inode: &Inode<C>, path: &str, visit: &mut F) -> Result<bool, Error>
+    pub fn walk<F>(&mut self, inode: &Inode, path: &str, visit: &mut F) -> Result<bool, Error>
     where
-        F: FnMut(&Self, &str, &Inode<C>, &Enhanced) -> Result<bool, Error>,
+        F: FnMut(&Self, &str, &Inode, &Enhanced) -> Result<bool, Error>,
     {
-        let enhanced = inode.enhance(&self.inner)?;
+        let enhanced = inode.enhance(&mut self.inner, &self.crypto)?;
 
         if !visit(self, path, inode, &enhanced).with_context(|| anyhow!("user closure failed"))? {
             return Ok(false);
@@ -438,7 +475,7 @@ impl<R: ReadAt, C: Crypto, M: MetadataCrypto> SuperBlock<R, C, M> {
 
     /// Parse a path, and find the directory entry it represents.
     /// Note that "/foo/../bar" will be treated literally, not resolved to "/bar" then looked up.
-    pub fn resolve_path(&self, path: &str) -> Result<DirEntry, Error> {
+    pub fn resolve_path(&mut self, path: &str) -> Result<DirEntry, Error> {
         let path = path.replace('\\', "/");
         let path = path.trim_end_matches('/');
 
@@ -469,7 +506,7 @@ impl<R: ReadAt, C: Crypto, M: MetadataCrypto> SuperBlock<R, C, M> {
         self.dir_entry_named(&curr, last)
     }
 
-    fn dir_entry_named(&self, inode: &Inode<C>, name: &str) -> Result<DirEntry, Error> {
+    fn dir_entry_named(&mut self, inode: &Inode, name: &str) -> Result<DirEntry, Error> {
         if let Enhanced::Directory(entries) = self.enhance(inode)? {
             if let Some(en) = entries.into_iter().find(|entry| entry.name == name) {
                 Ok(en)
@@ -482,18 +519,18 @@ impl<R: ReadAt, C: Crypto, M: MetadataCrypto> SuperBlock<R, C, M> {
     }
 
     /// Read the data from an inode. You might not want to call this on thigns that aren't regular files.
-    pub fn open<'a>(&'a self, inode: &'a Inode<C>) -> Result<TreeReader<'a, R, C, M>, Error> {
-        inode.reader(&self.inner)
+    pub fn open<'a>(&'a mut self, inode: &'a Inode, crypto: &'a C) -> Result<TreeReader<'a, R, C, M>, Error> {
+        inode.reader(&mut self.inner, crypto)
     }
 
     /// Load extra metadata about some types of entries.
-    pub fn enhance(&self, inode: &Inode<C>) -> Result<Enhanced, Error> {
-        inode.enhance(&self.inner)
+    pub fn enhance(&mut self, inode: &Inode) -> Result<Enhanced, Error> {
+        inode.enhance(&mut self.inner, &self.crypto)
     }
 }
 
 fn load_disc_bytes<R: ReadAt, M: MetadataCrypto>(
-    inner: &InnerReader<R, M>,
+    inner: &mut InnerReader<R, M>,
     block_size: u32,
     block: u64,
 ) -> Result<Vec<u8>, Error> {
@@ -503,10 +540,11 @@ fn load_disc_bytes<R: ReadAt, M: MetadataCrypto>(
     Ok(data)
 }
 
-impl<'a, C: Crypto> Inode<'a, C> {
-    fn reader<R: ReadAt, M: MetadataCrypto>(
-        &self,
-        inner: &'a InnerReader<R, M>,
+impl Inode {
+    fn reader<'a, R: ReadAt, C: Crypto, M: MetadataCrypto>(
+        &'a self,
+        inner: &'a mut InnerReader<R, M>,
+        crypto: &'a C
     ) -> Result<TreeReader<R, C, M>, Error> {
         let context = if matches!(self.stat.extracted_type, FileType::RegularFile) {
             self.get_encryption_context()
@@ -521,21 +559,22 @@ impl<'a, C: Crypto> Inode<'a, C> {
             self.core,
             self.checksum_prefix,
             context,
-            self.crypto,
+            crypto,
         )
         .with_context(|| anyhow!("opening inode <{}>", self.number))?)
     }
 
-    fn enhance<R: ReadAt, M: MetadataCrypto>(
+    fn enhance<R: ReadAt, C: Crypto, M: MetadataCrypto>(
         &self,
-        inner: &InnerReader<R, M>,
+        inner: &mut InnerReader<R, M>,
+        crypto: &C
     ) -> Result<Enhanced, Error> {
         Ok(match self.stat.extracted_type {
             FileType::RegularFile => Enhanced::RegularFile,
             FileType::Socket => Enhanced::Socket,
             FileType::Fifo => Enhanced::Fifo,
 
-            FileType::Directory => Enhanced::Directory(self.read_directory(inner)?),
+            FileType::Directory => Enhanced::Directory(self.read_directory(inner, crypto)?),
             FileType::SymbolicLink => {
                 Enhanced::SymbolicLink(if self.stat.size < u64::try_from(INODE_CORE_SIZE)? {
                     ensure!(
@@ -556,7 +595,7 @@ impl<'a, C: Crypto> Inode<'a, C> {
                             self.flags
                         ))
                     );
-                    std::str::from_utf8(&self.load_all(inner)?)
+                    std::str::from_utf8(&self.load_all(inner, crypto)?)
                         .with_context(|| anyhow!("long symlink is invalid utf-8"))?
                         .to_string()
                 })
@@ -572,14 +611,15 @@ impl<'a, C: Crypto> Inode<'a, C> {
         })
     }
 
-    fn load_all<R: ReadAt, M: MetadataCrypto>(
+    fn load_all<R: ReadAt, C: Crypto, M: MetadataCrypto>(
         &self,
-        inner: &InnerReader<R, M>,
+        inner: &mut InnerReader<R, M>,
+        crypto: &C
     ) -> Result<Vec<u8>, Error> {
         let size = usize::try_from(self.stat.size)?;
         let mut ret = vec![0u8; size];
 
-        self.reader(inner)?.read_exact(&mut ret)?;
+        self.reader(inner, crypto)?.read_exact(&mut ret)?;
 
         Ok(ret)
     }
@@ -588,9 +628,10 @@ impl<'a, C: Crypto> Inode<'a, C> {
         self.stat.xattrs.get("encryption.c")
     }
 
-    fn read_directory<R: ReadAt, M: MetadataCrypto>(
+    fn read_directory<R: ReadAt, C: Crypto, M: MetadataCrypto>(
         &self,
-        inner: &InnerReader<R, M>,
+        inner: &mut InnerReader<R, M>,
+        crypto: &C
     ) -> Result<Vec<DirEntry>, Error> {
         let mut dirs = Vec::with_capacity(40);
 
@@ -604,7 +645,7 @@ impl<'a, C: Crypto> Inode<'a, C> {
                 ))
             );
 
-            self.load_all(inner)?
+            self.load_all(inner, crypto)?
         };
 
         let total_len = data.len();
@@ -633,7 +674,7 @@ impl<'a, C: Crypto> Inode<'a, C> {
                     self.get_encryption_context(),
                     [b".".as_slice(), b"..".as_slice()].contains(&name.as_slice()),
                 ) {
-                    self.crypto.decrypt_filename(context, &name)?
+                    crypto.decrypt_filename(context, &name)?
                 } else {
                     name
                 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,6 +316,18 @@ impl<R: ReadAt, C: Crypto, M: MetadataCrypto> SuperBlock<R, C, M> {
         self.crypto = crypto;
     }
 
+    pub fn get_metadata_crypto_mut(&mut self) -> &mut M {
+        &mut self.inner.metadata_crypto
+    }
+
+    pub fn get_metadata_crypto(&self) -> &M {
+        &self.inner.metadata_crypto
+    }
+
+    pub fn set_metadata_crypto(&mut self, crypto: M) {
+        self.inner.metadata_crypto = crypto;
+    }
+
     /// Returns inner R, consuming self
     pub fn into_inner(self) -> R {
         self.inner.inner

--- a/src/none_crypto.rs
+++ b/src/none_crypto.rs
@@ -1,0 +1,22 @@
+use crate::Crypto;
+
+pub struct NoneCrypto {}
+
+impl Crypto for NoneCrypto {
+    fn decrypt_filename(
+        &self,
+        _context: &[u8],
+        encrypted_name: &[u8],
+    ) -> Result<Vec<u8>, anyhow::Error> {
+        Ok(encrypted_name.to_vec())
+    }
+
+    fn decrypt_page(
+        &self,
+        _context: &[u8],
+        _page: &mut [u8],
+        _page_addr: u64,
+    ) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+}

--- a/src/none_crypto.rs
+++ b/src/none_crypto.rs
@@ -18,7 +18,9 @@ impl Crypto for NoneCrypto {
         &self,
         _context: &[u8],
         _page: &mut [u8],
+        _page_offset: u64,
         _page_addr: u64,
+        _ino: u32,
     ) -> Result<(), Error> {
         Ok(())
     }

--- a/src/none_crypto.rs
+++ b/src/none_crypto.rs
@@ -1,13 +1,16 @@
-use crate::Crypto;
+use crate::{Crypto, MetadataCrypto};
+use anyhow::Error;
 
 pub struct NoneCrypto {}
 
+impl MetadataCrypto for NoneCrypto {
+    fn decrypt(&self, _page: &mut [u8], _page_addr: u64) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
 impl Crypto for NoneCrypto {
-    fn decrypt_filename(
-        &self,
-        _context: &[u8],
-        encrypted_name: &[u8],
-    ) -> Result<Vec<u8>, anyhow::Error> {
+    fn decrypt_filename(&self, _context: &[u8], encrypted_name: &[u8]) -> Result<Vec<u8>, Error> {
         Ok(encrypted_name.to_vec())
     }
 
@@ -16,7 +19,7 @@ impl Crypto for NoneCrypto {
         _context: &[u8],
         _page: &mut [u8],
         _page_addr: u64,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/none_crypto.rs
+++ b/src/none_crypto.rs
@@ -4,13 +4,18 @@ use anyhow::Error;
 pub struct NoneCrypto {}
 
 impl MetadataCrypto for NoneCrypto {
-    fn decrypt(&self, _page: &mut [u8], _page_addr: u64) -> Result<(), Error> {
+    fn decrypt_page(&self, _page: &mut [u8], _page_addr: u64) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl Crypto for NoneCrypto {
-    fn decrypt_filename(&self, _context: &[u8], encrypted_name: &[u8]) -> Result<Vec<u8>, Error> {
+    fn decrypt_filename(
+        &self,
+        _context: &[u8],
+        encrypted_name: &[u8],
+        _ino: u32,
+    ) -> Result<Vec<u8>, Error> {
         Ok(encrypted_name.to_vec())
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -626,6 +626,8 @@ fn read_xattrs(
                 4 => "trusted.",
                 6 => "security.",
                 7 => "system.",
+                8 => "system.richacl",
+                9 => assumption_failed("node is encrypted"), // EXT4_XATTR_INDEX_ENCRYPTION
                 _ => bail!(unsupported_feature(format!(
                     "unsupported name prefix encoding: {}",
                     e_name_prefix_magic

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -234,11 +234,10 @@ where
     inner.read_u32::<LittleEndian>()?; /* When the filesystem was created */
     let mut s_jnl_blocks = [0; 17 * 4];
     inner.read_exact(&mut s_jnl_blocks)?; /* Backup of the journal inode */
-
-    let s_blocks_count_hi = if !long_structs {
-        None
-    } else {
+    let s_blocks_count_hi = if long_structs {
         Some(inner.read_u32::<LittleEndian>()?) /* Blocks count */
+    } else {
+        None
     };
     ////    let s_r_blocks_count_hi =
     //        if !long_structs { None } else {
@@ -305,16 +304,6 @@ where
         }
     };
 
-    if !long_structs {
-        ensure!(
-            0 == s_desc_size,
-            assumption_failed(format!(
-                "outside long mode, block group desc size must be zero, not {}",
-                s_desc_size
-            ))
-        );
-    }
-
     ensure!(
         1 == s_rev_level,
         unsupported_feature(format!("rev level {}", s_rev_level))
@@ -346,6 +335,7 @@ where
         s_inodes_per_group,
         block_size,
         s_inode_size,
+        long_structs,
     )?;
 
     let uuid_checksum = if has_checksums {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -201,8 +201,8 @@ pub fn superblock<R: ReadAt, C: Crypto, M: MetadataCrypto>(
         not_found("checksums are disabled, but required by options")
     );
 
-    let mut s_uuid = [0; 16];
-    inner.read_exact(&mut s_uuid)?; /* 128-bit uuid for volume */
+    let mut uuid = [0; 16];
+    inner.read_exact(&mut uuid)?; /* 128-bit uuid for volume */
     let mut s_volume_name = [0u8; 16];
     inner.read_exact(&mut s_volume_name)?; /* volume name */
     let mut s_last_mounted = [0u8; 64];
@@ -347,7 +347,7 @@ pub fn superblock<R: ReadAt, C: Crypto, M: MetadataCrypto>(
 
     let uuid_checksum = if has_checksums {
         // TODO: check s_checksum_seed
-        Some(ext4_style_crc32c_le(!0, &s_uuid))
+        Some(ext4_style_crc32c_le(!0, &uuid))
     } else {
         None
     };
@@ -355,6 +355,7 @@ pub fn superblock<R: ReadAt, C: Crypto, M: MetadataCrypto>(
     Ok(crate::SuperBlock {
         inner: reader,
         load_xattrs,
+        uuid,
         uuid_checksum,
         groups,
         crypto,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -628,7 +628,7 @@ fn read_xattrs(
                 6 => "security.",
                 7 => "system.",
                 8 => "system.richacl",
-                9 => bail!(assumption_failed("node is encrypted")), // EXT4_XATTR_INDEX_ENCRYPTION
+                9 => "encryption.", // EXT4_XATTR_INDEX_ENCRYPTION
                 _ => bail!(unsupported_feature(format!(
                     "unsupported name prefix encoding: {}",
                     e_name_prefix_magic

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -275,17 +275,18 @@ where
         );
     }
 
-    {
-        const S_STATE_UNMOUNTED_CLEANLY: u16 = 0b01;
-        const S_STATE_ERRORS_DETECTED: u16 = 0b10;
-
-        if s_state & S_STATE_UNMOUNTED_CLEANLY == 0 || s_state & S_STATE_ERRORS_DETECTED != 0 {
-            return Err(parse_error(format!(
-                "filesystem is not in a clean state: {:b}",
-                s_state
-            )));
-        }
-    }
+    // Do not check file system state
+    // {
+    //     const S_STATE_UNMOUNTED_CLEANLY: u16 = 0b01;
+    //     const S_STATE_ERRORS_DETECTED: u16 = 0b10;
+    //
+    //     if s_state & S_STATE_UNMOUNTED_CLEANLY == 0 || s_state & S_STATE_ERRORS_DETECTED != 0 {
+    //         return Err(parse_error(format!(
+    //             "filesystem is not in a clean state: {:b}",
+    //             s_state
+    //         )));
+    //     }
+    // }
 
     if 0 == s_inodes_per_group {
         return Err(parse_error("inodes per group cannot be zero".to_string()));

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -14,13 +14,13 @@ use byteorder::{ByteOrder, LittleEndian, ReadBytesExt};
 use positioned_io::Cursor;
 use positioned_io::ReadAt;
 
-use crate::not_found;
 use crate::parse_error;
 use crate::read_le16;
 use crate::read_le32;
 use crate::unsupported_feature;
 use crate::Time;
 use crate::{assumption_failed, read_lei32};
+use crate::{not_found, Crypto};
 
 const EXT4_SUPER_MAGIC: u16 = 0xEF53;
 const INODE_BASE_LEN: usize = 128;
@@ -76,7 +76,11 @@ bitflags! {
     }
 }
 
-pub fn superblock<R>(mut reader: R, options: &crate::Options) -> Result<crate::SuperBlock<R>, Error>
+pub fn superblock<R, C: Crypto>(
+    mut reader: R,
+    options: &crate::Options,
+    crypto: C,
+) -> Result<crate::SuperBlock<R, C>, Error>
 where
     R: ReadAt,
 {
@@ -352,6 +356,7 @@ where
         load_xattrs,
         uuid_checksum,
         groups,
+        crypto,
     })
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -484,22 +484,26 @@ where
 
         if let Some(high) = i_checksum_hi {
             let expected = u32::from(l_i_checksum_lo) | (u32::from(high) << 16);
-            ensure!(
-                expected == computed,
-                assumption_failed(format!(
-                    "full checksum mismatch: on-disc: {:08x} computed: {:08x}",
-                    expected, computed
-                ))
-            );
+
+            if computed != expected {
+                if cfg!(feature = "verify-checksums") {
+                    bail!(assumption_failed(format!(
+                        "full checksum mismatch: on-disc: {:08x} computed: {:08x}",
+                        expected, computed
+                    )))
+                }
+            }
         } else {
             let short_computed = u16::try_from(computed & 0xFFFF).map_err(map_lib_error_to_io)?;
-            ensure!(
-                l_i_checksum_lo == short_computed,
-                assumption_failed(format!(
-                    "short checksum mismatch: on-disc: {:04x} computed: {:04x}",
-                    l_i_checksum_lo, short_computed
-                ))
-            );
+
+            if short_computed != l_i_checksum_lo {
+                if cfg!(feature = "verify-checksums") {
+                    bail!(assumption_failed(format!(
+                        "short checksum mismatch: on-disc: {:04x} computed: {:04x}",
+                        l_i_checksum_lo, short_computed
+                    )))
+                }
+            }
         }
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -167,7 +167,8 @@ where
         | IncompatibleFeature::EXTENTS
         | IncompatibleFeature::FLEX_BG
         | IncompatibleFeature::RECOVER
-        | IncompatibleFeature::SIXTY_FOUR_BIT;
+        | IncompatibleFeature::SIXTY_FOUR_BIT
+        | IncompatibleFeature::ENCRYPT;
 
     if incompatible_features.intersects(!supported_incompatible_features) {
         return Err(parse_error(format!(

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3,6 +3,7 @@ use std::convert::TryFrom;
 use std::io;
 use std::io::Read;
 use std::io::Seek;
+use std::io::Cursor;
 
 use anyhow::anyhow;
 use anyhow::bail;
@@ -11,8 +12,6 @@ use anyhow::Context;
 use anyhow::Error;
 use bitflags::bitflags;
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt};
-use positioned_io::Cursor;
-use positioned_io::ReadAt;
 
 use crate::unsupported_feature;
 use crate::Time;
@@ -21,6 +20,7 @@ use crate::{map_lib_error_to_io, parse_error};
 use crate::{not_found, Crypto};
 use crate::{read_le16, MetadataCrypto};
 use crate::{read_le32, InnerReader};
+use crate::ReadAt;
 
 const EXT4_SUPER_MAGIC: u16 = 0xEF53;
 const INODE_BASE_LEN: usize = 128;
@@ -82,7 +82,7 @@ pub fn superblock<R: ReadAt, C: Crypto, M: MetadataCrypto>(
     crypto: C,
     metadata_crypto: M,
 ) -> Result<crate::SuperBlock<R, C, M>, Error> {
-    let reader = InnerReader::new(raw_reader, metadata_crypto);
+    let mut reader = InnerReader::new(raw_reader, metadata_crypto);
     let mut entire_superblock = [0u8; 1024];
     reader.read_exact_at(1024, &mut entire_superblock)?;
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -627,7 +627,7 @@ fn read_xattrs(
                 6 => "security.",
                 7 => "system.",
                 8 => "system.richacl",
-                9 => assumption_failed("node is encrypted"), // EXT4_XATTR_INDEX_ENCRYPTION
+                9 => bail!(assumption_failed("node is encrypted")), // EXT4_XATTR_INDEX_ENCRYPTION
                 _ => bail!(unsupported_feature(format!(
                     "unsupported name prefix encoding: {}",
                     e_name_prefix_magic

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -77,12 +77,12 @@ bitflags! {
 }
 
 pub fn superblock<R: ReadAt, C: Crypto, M: MetadataCrypto>(
-    mut raw_reader: R,
+    raw_reader: R,
     options: &crate::Options,
     crypto: C,
     metadata_crypto: M,
 ) -> Result<crate::SuperBlock<R, C, M>, Error> {
-    let mut reader = InnerReader::new(raw_reader, metadata_crypto);
+    let reader = InnerReader::new(raw_reader, metadata_crypto);
     let mut entire_superblock = [0u8; 1024];
     reader.read_exact_at(1024, &mut entire_superblock)?;
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -281,18 +281,19 @@ pub fn superblock<R: ReadAt, C: Crypto, M: MetadataCrypto>(
         );
     }
 
-    // Do not check file system state
-    // {
-    //     const S_STATE_UNMOUNTED_CLEANLY: u16 = 0b01;
-    //     const S_STATE_ERRORS_DETECTED: u16 = 0b10;
-    //
-    //     if s_state & S_STATE_UNMOUNTED_CLEANLY == 0 || s_state & S_STATE_ERRORS_DETECTED != 0 {
-    //         return Err(parse_error(format!(
-    //             "filesystem is not in a clean state: {:b}",
-    //             s_state
-    //         )));
-    //     }
-    // }
+    {
+        const S_STATE_UNMOUNTED_CLEANLY: u16 = 0b01;
+        const S_STATE_ERRORS_DETECTED: u16 = 0b10;
+
+        if s_state & S_STATE_UNMOUNTED_CLEANLY == 0 || s_state & S_STATE_ERRORS_DETECTED != 0 {
+            if cfg!(feature = "verify-clean-state") {
+                return Err(parse_error(format!(
+                    "filesystem is not in a clean state: {:b}",
+                    s_state
+                )));
+            }
+        }
+    }
 
     if 0 == s_inodes_per_group {
         return Err(parse_error("inodes per group cannot be zero".to_string()));

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -606,9 +606,8 @@ fn read_xattrs(
         let e_name_len = reading[0x00];
         let e_name_prefix_magic = reading[0x01];
         let e_value_offset = read_le16(&reading[0x02..0x04]);
-        let e_block = read_le32(&reading[0x04..0x08]);
 
-        if 0 == e_name_len && 0 == e_name_prefix_magic && 0 == e_value_offset && 0 == e_block {
+        if 0 == e_name_len && 0 == e_name_prefix_magic && 0 == e_value_offset {
             break;
         }
 

--- a/tests/generated-images.rs
+++ b/tests/generated-images.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use std::ffi::OsStr;
 use std::fs;
 use std::io;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::Read;
 use std::path::PathBuf;
 use std::process::Stdio;
 


### PR DESCRIPTION
Using [ext4 documentation](https://ext4.wiki.kernel.org/index.php/Ext4_Disk_Layout#Block_Group_Descriptors) supported images with "the 64bit feature is enabled and s_desc_size > 32"